### PR TITLE
fix: retry on Iceberg CommitFailedException and serialize CI on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,19 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Serialize integration tests per ref so concurrent pushes (e.g. back-to-back
-  # dependabot merges to main) don't write to the same Iceberg table in parallel
-  # and trigger optimistic-concurrency commit conflicts.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Serialize integration tests so concurrent runs don't write to the same
+  # Iceberg table in parallel and trigger optimistic-concurrency commit conflicts.
+  #
+  # For pull_request events, key on the PR number so forked PRs that happen to
+  # share a branch name with another PR don't collide, and so each PR gets its
+  # own queue with cancel-in-progress (newer pushes supersede older runs).
+  #
+  # For all other events (push to main, workflow_dispatch, etc.) key on
+  # github.ref and disable cancel-in-progress so back-to-back merges to main
+  # queue rather than cancel each other — this is required for post-merge
+  # integration coverage and is the whole reason this concurrency group exists.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # Serialize integration tests per ref so concurrent pushes (e.g. back-to-back
+  # dependabot merges to main) don't write to the same Iceberg table in parallel
+  # and trigger optimistic-concurrency commit conflicts.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/target_s3tables/iceberg.py
+++ b/target_s3tables/iceberg.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 import pyarrow as pa
 from pyiceberg.catalog import load_catalog
-from pyiceberg.exceptions import NoSuchTableError
+from pyiceberg.exceptions import CommitFailedException, NoSuchTableError
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.types import (
@@ -81,6 +81,7 @@ def retry(  # noqa: PLR0913
     max_attempts: int = 8,
     base_delay_s: float = 1.0,
     max_delay_s: float = 60.0,
+    before_retry: t.Callable[[], None] | None = None,
 ) -> t.Any:
     """Retry helper with exponential backoff + jitter for transient HTTP errors."""
     attempt = 0
@@ -104,10 +105,17 @@ def retry(  # noqa: PLR0913
                 delay,
             )
             time.sleep(delay)
+            if before_retry is not None:
+                before_retry()
 
 
 def _is_retriable_exception(exc: Exception) -> bool:
     """Determine if an exception is transient and should be retried."""
+    # Iceberg optimistic-concurrency conflict: another writer committed first.
+    # Retrying after refreshing the table's snapshot is the documented recovery.
+    if isinstance(exc, CommitFailedException):
+        return True
+
     status_code = getattr(exc, "status_code", None)
     if status_code is None and hasattr(exc, "response"):
         status_code = getattr(getattr(exc, "response"), "status_code", None)
@@ -826,17 +834,30 @@ def write_arrow_to_table(
         else:
             table.overwrite(arrow_table)
 
+    def _refresh() -> None:
+        table.refresh()
+
     try:
         if config.write_mode == "overwrite":
-            retry(_overwrite, log=log, op="overwrite")
+            retry(_overwrite, log=log, op="overwrite", before_retry=_refresh)
         else:
-            retry(_append, log=log, op="append")
+            retry(_append, log=log, op="append", before_retry=_refresh)
     except TypeError:
         # Older PyIceberg versions may not support snapshot_properties kwarg.
         if config.write_mode == "overwrite":
-            retry(lambda: table.overwrite(arrow_table), log=log, op="overwrite")
+            retry(
+                lambda: table.overwrite(arrow_table),
+                log=log,
+                op="overwrite",
+                before_retry=_refresh,
+            )
         else:
-            retry(lambda: table.append(arrow_table), log=log, op="append")
+            retry(
+                lambda: table.append(arrow_table),
+                log=log,
+                op="append",
+                before_retry=_refresh,
+            )
     except Exception as exc:  # noqa: BLE001
         if config.write_mode == "append" and is_table_partitioned(table):
             raise RuntimeError(

--- a/target_s3tables/iceberg.py
+++ b/target_s3tables/iceberg.py
@@ -81,9 +81,22 @@ def retry(  # noqa: PLR0913
     max_attempts: int = 8,
     base_delay_s: float = 1.0,
     max_delay_s: float = 60.0,
-    before_retry: t.Callable[[], None] | None = None,
+    before_retry: t.Callable[[BaseException], None] | None = None,
 ) -> t.Any:
-    """Retry helper with exponential backoff + jitter for transient HTTP errors."""
+    """Retry helper with exponential backoff + jitter.
+
+    Retries on transient HTTP/network errors (HTTP 429, 5xx, timeouts,
+    connection errors, throttling) as well as Iceberg ``CommitFailedException``
+    raised by optimistic-concurrency conflicts. See
+    :func:`_is_retriable_exception` for the full classification.
+
+    If ``before_retry`` is provided, it is invoked with the caught exception
+    after sleeping and before the next attempt. Callers can inspect the
+    exception type to take recovery actions for specific failures (for example,
+    refreshing a table snapshot only on ``CommitFailedException``). Exceptions
+    raised by ``before_retry`` propagate and abort the retry loop, so callers
+    that want retries to continue regardless should swallow their own errors.
+    """
     attempt = 0
     while True:
         attempt += 1
@@ -106,7 +119,7 @@ def retry(  # noqa: PLR0913
             )
             time.sleep(delay)
             if before_retry is not None:
-                before_retry()
+                before_retry(exc)
 
 
 def _is_retriable_exception(exc: Exception) -> bool:
@@ -834,14 +847,38 @@ def write_arrow_to_table(
         else:
             table.overwrite(arrow_table)
 
-    def _refresh() -> None:
-        table.refresh()
+    def _refresh_on_commit_conflict(exc: BaseException) -> None:
+        # Only refresh on CommitFailedException — transient HTTP/network errors
+        # do not require (and may not benefit from) re-reading the table
+        # metadata. Tolerate refresh failures so a flaky catalog request here
+        # does not abort an otherwise-recoverable retry loop.
+        if not isinstance(exc, CommitFailedException):
+            return
+        try:
+            table.refresh()
+        # pylint: disable-next=broad-except
+        except Exception as refresh_exc:  # noqa: BLE001
+            log.warning(
+                "table.refresh() failed during retry recovery; "
+                "continuing with stale metadata: %s",
+                _format_exception_short(refresh_exc),
+            )
 
     try:
         if config.write_mode == "overwrite":
-            retry(_overwrite, log=log, op="overwrite", before_retry=_refresh)
+            retry(
+                _overwrite,
+                log=log,
+                op="overwrite",
+                before_retry=_refresh_on_commit_conflict,
+            )
         else:
-            retry(_append, log=log, op="append", before_retry=_refresh)
+            retry(
+                _append,
+                log=log,
+                op="append",
+                before_retry=_refresh_on_commit_conflict,
+            )
     except TypeError:
         # Older PyIceberg versions may not support snapshot_properties kwarg.
         if config.write_mode == "overwrite":
@@ -849,14 +886,14 @@ def write_arrow_to_table(
                 lambda: table.overwrite(arrow_table),
                 log=log,
                 op="overwrite",
-                before_retry=_refresh,
+                before_retry=_refresh_on_commit_conflict,
             )
         else:
             retry(
                 lambda: table.append(arrow_table),
                 log=log,
                 op="append",
-                before_retry=_refresh,
+                before_retry=_refresh_on_commit_conflict,
             )
     except Exception as exc:  # noqa: BLE001
         if config.write_mode == "append" and is_table_partitioned(table):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,65 @@
+"""Unit tests for the retry helper and retriable-exception classification."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pyiceberg.exceptions import CommitFailedException
+
+from target_s3tables.iceberg import _is_retriable_exception, retry
+
+
+def test_commit_failed_exception_is_retriable() -> None:
+    exc = CommitFailedException("branch main has changed")
+    assert _is_retriable_exception(exc) is True
+
+
+def test_retry_recovers_from_commit_conflict_and_calls_before_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("target_s3tables.iceberg.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+    refreshed = {"n": 0}
+
+    def flaky() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise CommitFailedException("branch main has changed")
+        return "ok"
+
+    def refresh() -> None:
+        refreshed["n"] += 1
+
+    result = retry(
+        flaky,
+        log=logging.getLogger("test"),
+        op="append",
+        max_attempts=5,
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+        before_retry=refresh,
+    )
+
+    assert result == "ok"
+    assert attempts["n"] == 3
+    # before_retry runs once before each retry, not before the first attempt.
+    assert refreshed["n"] == 2
+
+
+def test_retry_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("target_s3tables.iceberg.time.sleep", lambda _s: None)
+
+    def always_conflict() -> None:
+        raise CommitFailedException("branch main has changed")
+
+    with pytest.raises(CommitFailedException):
+        retry(
+            always_conflict,
+            log=logging.getLogger("test"),
+            op="append",
+            max_attempts=3,
+            base_delay_s=0.0,
+            max_delay_s=0.0,
+        )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -10,6 +10,14 @@ from pyiceberg.exceptions import CommitFailedException
 from target_s3tables.iceberg import _is_retriable_exception, retry
 
 
+class _HttpError(Exception):
+    """Minimal stand-in for a transient HTTP error with a status_code."""
+
+    def __init__(self, status_code: int, message: str = "boom") -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
 def test_commit_failed_exception_is_retriable() -> None:
     exc = CommitFailedException("branch main has changed")
     assert _is_retriable_exception(exc) is True
@@ -21,7 +29,7 @@ def test_retry_recovers_from_commit_conflict_and_calls_before_retry(
     monkeypatch.setattr("target_s3tables.iceberg.time.sleep", lambda _s: None)
 
     attempts = {"n": 0}
-    refreshed = {"n": 0}
+    seen_excs: list[BaseException] = []
 
     def flaky() -> str:
         attempts["n"] += 1
@@ -29,8 +37,8 @@ def test_retry_recovers_from_commit_conflict_and_calls_before_retry(
             raise CommitFailedException("branch main has changed")
         return "ok"
 
-    def refresh() -> None:
-        refreshed["n"] += 1
+    def before_retry(exc: BaseException) -> None:
+        seen_excs.append(exc)
 
     result = retry(
         flaky,
@@ -39,13 +47,15 @@ def test_retry_recovers_from_commit_conflict_and_calls_before_retry(
         max_attempts=5,
         base_delay_s=0.0,
         max_delay_s=0.0,
-        before_retry=refresh,
+        before_retry=before_retry,
     )
 
     assert result == "ok"
     assert attempts["n"] == 3
-    # before_retry runs once before each retry, not before the first attempt.
-    assert refreshed["n"] == 2
+    # before_retry runs once before each retry, not before the first attempt,
+    # and receives the caught exception each time.
+    assert len(seen_excs) == 2
+    assert all(isinstance(e, CommitFailedException) for e in seen_excs)
 
 
 def test_retry_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -63,3 +73,35 @@ def test_retry_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> N
             base_delay_s=0.0,
             max_delay_s=0.0,
         )
+
+
+def test_retry_passes_http_error_to_before_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """before_retry should receive transient HTTP errors as well, so the
+    callback can decide whether the exception is one it cares about."""
+    monkeypatch.setattr("target_s3tables.iceberg.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+    seen_excs: list[BaseException] = []
+
+    def flaky() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise _HttpError(503, "service unavailable")
+        return "ok"
+
+    result = retry(
+        flaky,
+        log=logging.getLogger("test"),
+        op="append",
+        max_attempts=5,
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+        before_retry=seen_excs.append,
+    )
+
+    assert result == "ok"
+    assert len(seen_excs) == 1
+    assert isinstance(seen_excs[0], _HttpError)
+    assert seen_excs[0].status_code == 503


### PR DESCRIPTION
## Summary

- **Production fix:** Treat `pyiceberg.exceptions.CommitFailedException` as retriable in `target_s3tables/iceberg.py`. Adds a `before_retry` hook to `retry()` and wires `table.refresh()` into `write_arrow_to_table` so the next attempt commits against the latest snapshot.
- **CI fix:** Change the workflow concurrency group from `github.run_id` (unique per run) to `github.ref`, so concurrent pushes to `main` (e.g. back-to-back dependabot merges) don't run integration tests in parallel against the same Iceberg table.
- **Tests:** New `tests/test_retry.py` covering retriable classification, retry recovery (and `before_retry` invocation), and exhaustion after `max_attempts`.

## Why

[Run 25261111667](https://github.com/amaingot/target-s3tables/actions/runs/25261111667/job/74068454393) failed only on `Glue Rest / Python 3.14` with:

```
pyiceberg.exceptions.CommitFailedException: Request doesn't meet the requirement condition:
  Requirement failed: branch main has changed:
    expected id 227674131135758519 != 2655889724749842011
```

Four dependabot PRs were merged within ~30 seconds. Each merge spawned its own CI run, and two of those runs' Python 3.14 Glue Rest jobs overlapped (20:27:28Z–20:28:12Z) writing to the same `glue_rest_314animals` table. Iceberg's optimistic-concurrency check rejected one commit. Our `_is_retriable_exception` only matched HTTP status codes or class-name tokens (`timeout`, `connectionerror`, `throttl`) — `CommitFailedException` matched none, so the failure propagated.

This is a real production hazard too: any two loaders writing the same table concurrently would hit it.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_integration_smoke.py` — 32 existing + 3 new tests pass
- [ ] CI integration tests pass on this branch
- [ ] Verify next push to `main` after merge doesn't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)