### PR TITLE
fix: retry PyArrow CRC64NVME OSError during S3 multipart upload

### DIFF
--- a/target_s3tables/iceberg.py
+++ b/target_s3tables/iceberg.py
@@ -129,6 +129,16 @@ def _is_retriable_exception(exc: Exception) -> bool:
     if isinstance(exc, CommitFailedException):
         return True
 
+    # PyArrow raises a plain OSError when the bundled AWS C++ SDK rejects an S3
+    # multipart-upload part with HTTP 400 BadDigest because the CRC64NVME it
+    # computed for the part does not match what S3 calculated. Retrying allocates
+    # a fresh upload ID and a new Parquet file, so the bad part is never
+    # resubmitted. See amaingot/target-s3tables#44.
+    if isinstance(exc, OSError):
+        msg = str(exc)
+        if "CRC64NVME" in msg or "BadDigest" in msg:
+            return True
+
     status_code = getattr(exc, "status_code", None)
     if status_code is None and hasattr(exc, "response"):
         status_code = getattr(getattr(exc, "response"), "status_code", None)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -105,3 +105,59 @@ def test_retry_passes_http_error_to_before_retry(
     assert len(seen_excs) == 1
     assert isinstance(seen_excs[0], _HttpError)
     assert seen_excs[0].status_code == 503
+
+
+# Verbatim from amaingot/target-s3tables#44 so the substring check is exercised
+# end-to-end against a realistic PyArrow error string.
+_CRC64NVME_MESSAGE = (
+    "When uploading part for key 'data/00000-0-abc.parquet' in bucket "
+    "'x--table-s3': AWS Error UNKNOWN (HTTP status 400) during UploadPart "
+    "operation: Unable to parse ExceptionName: BadDigest Message: The "
+    "CRC64NVME you specified did not match the calculated checksum."
+)
+
+
+def test_pyarrow_crc64nvme_oserror_is_retriable() -> None:
+    exc = OSError(_CRC64NVME_MESSAGE)
+    assert _is_retriable_exception(exc) is True
+
+
+def test_pyarrow_baddigest_oserror_is_retriable() -> None:
+    exc = OSError("BadDigest: digest mismatch on UploadPart")
+    assert _is_retriable_exception(exc) is True
+
+
+def test_unrelated_oserror_is_not_retriable() -> None:
+    """Regression guard: only the CRC64NVME / BadDigest signature should retry.
+
+    Blanket OSError retries would swallow fatal errors like disk-full or bad
+    credentials and burn 8 attempts of backoff on each.
+    """
+    assert _is_retriable_exception(OSError("No space left on device")) is False
+    assert _is_retriable_exception(OSError("Permission denied")) is False
+
+
+def test_retry_recovers_from_crc64nvme_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("target_s3tables.iceberg.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def flaky() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise OSError(_CRC64NVME_MESSAGE)
+        return "ok"
+
+    result = retry(
+        flaky,
+        log=logging.getLogger("test"),
+        op="append",
+        max_attempts=5,
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+    )
+
+    assert result == "ok"
+    assert attempts["n"] == 2

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -107,8 +107,9 @@ def test_retry_passes_http_error_to_before_retry(
     assert seen_excs[0].status_code == 503
 
 
-# Verbatim from amaingot/target-s3tables#44 so the substring check is exercised
-# end-to-end against a realistic PyArrow error string.
+# Adapted from amaingot/target-s3tables#44 (key and bucket shortened) so the
+# substring check is exercised end-to-end against a realistic PyArrow error
+# string.
 _CRC64NVME_MESSAGE = (
     "When uploading part for key 'data/00000-0-abc.parquet' in bucket "
     "'x--table-s3': AWS Error UNKNOWN (HTTP status 400) during UploadPart "


### PR DESCRIPTION
## Summary

- Teaches `_is_retriable_exception` to recognise PyArrow's `OSError` with `CRC64NVME` / `BadDigest` in the message, which AWS returns as HTTP 400 when its bundled C++ SDK computes a wrong checksum for a multipart-upload part. The pipeline previously aborted the whole run on this transient error.
- Retry is safe: a fresh `table.append()` allocates a new upload ID and a new Parquet file, so the bad part is never resubmitted; PyIceberg commits are atomic.
- Adds 4 unit tests — retriable CRC64NVME, retriable BadDigest, non-retriable plain `OSError` regression guard, and a full `retry()` recovery loop.

Closes #44

## Test plan

- [x] `uv run pytest tests/test_retry.py -v` — 8/8 pass (4 existing + 4 new)
- [x] `uv run pytest tests/` — 37/37 pass (excluding integration smoke)
- [x] `uv run mypy target_s3tables tests` — clean
- [ ] First failing prod run after merge confirms the end-to-end retry path (no synthetic reproducer exists since the CRC mismatch is data-dependent and requires a real S3 Tables bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)