### PR TITLE
fix(ci): sync uv.lock in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please's built-in uv.lock updater silently no-ops on this
+      # project ("No entries modified in $.package[?(@.name=='target-s3tables')].version"
+      # in the log), so when it bumps pyproject.toml the lockfile is left
+      # behind and every job that runs `uv sync --locked` fails. Regenerate
+      # the lockfile here and push the fix back onto the release PR branch.
+      #
+      # Note: this push uses GITHUB_TOKEN, which does not retrigger CI on the
+      # PR. If unit tests need to re-run after the lockfile sync, click
+      # "Re-run all jobs" on the PR or push a trivial commit. Switching the
+      # release-please-action `token:` input to a PAT or GitHub App token
+      # avoids that.
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup uv
+        if: ${{ steps.release.outputs.prs }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ">=0.8"
+
+      - name: Sync uv.lock to match pyproject.toml
+        if: ${{ steps.release.outputs.prs }}
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock"
+          git push


### PR DESCRIPTION
## Summary

- After `googleapis/release-please-action@v4` bumps the version in `pyproject.toml`, regenerate `uv.lock` and push the fix back onto the release PR branch.
- Gates the extra work on `steps.release.outputs.prs` so normal pushes (no release PR created/updated) are a no-op.

## Why

release-please's built-in uv.lock updater silently no-ops on this project — the log for the v0.0.7 run on `main` literally said:

```
⚠ No entries modified in $.package[?(@.name=='target-s3tables')].version
```

So `pyproject.toml` went to `0.0.7` but `uv.lock` stayed at `0.0.6`, and every job that runs `uv sync --locked` (unit tests on 3.10–3.14, type checking) failed on PR #46 with:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

This PR makes the release workflow self-correct so the next release doesn't bleed the same way. PR #46 was patched manually for now.

## Caveat

The auto-push uses `GITHUB_TOKEN`, which GitHub deliberately does not retrigger CI from (anti-loop safeguard). The lockfile commit will appear on the release PR, but the unit-test checks stay at their prior status until someone clicks "Re-run all jobs" or pushes another commit. Wiring a PAT or GitHub App token into the `release-please-action` `token:` input would close that gap.

## Test plan

- [ ] Merge to main and let it run as a no-op (no release PR is open after PR #46 merges).
- [ ] On the next conventional commit that lands and triggers a release, confirm the new release PR has a `chore: sync uv.lock` commit and that `uv.lock`'s `target-s3tables` version matches `pyproject.toml`.
- [ ] Confirm CI on that release PR is green (after a manual re-run if needed — see caveat above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)